### PR TITLE
Cholesky: Fix dgemm order in stream_df_cholesky, task creation in stream_df_cholesky_peek and force verification over the whole computed matrix

### DIFF
--- a/examples/cholesky/stream_df_cholesky.c
+++ b/examples/cholesky/stream_df_cholesky.c
@@ -253,8 +253,8 @@ void create_dgemm_task(double* input_data, int x, int blocks, int block_size, in
 
 	  cblas_dgemm (CblasRowMajor, CblasNoTrans, CblasTrans,
 		       block_size, block_size, block_size,
-		       -1.0, upper_in, block_size,
-		       lower_in, block_size,
+		       -1.0, lower_in, block_size,
+		       upper_in, block_size,
 		       1.0, out, block_size);
 
 	  if(stage+2 < x)
@@ -270,8 +270,8 @@ void create_dgemm_task(double* input_data, int x, int blocks, int block_size, in
 
 	cblas_dgemm (CblasRowMajor, CblasNoTrans, CblasTrans,
 		     block_size, block_size, block_size,
-		     -1.0, upper_in, block_size,
-		     lower_in, block_size,
+		     -1.0, lower_in, block_size,
+		     upper_in, block_size,
 		     1.0, out, block_size);
 
 	if(stage+2 < x)

--- a/examples/cholesky/stream_df_cholesky.c
+++ b/examples/cholesky/stream_df_cholesky.c
@@ -440,7 +440,7 @@ static inline void
 verify (int N, double *data, double* seq_data)
 {
   for(int x = 0; x < N; x++) {
-    for(int y = 0; y <= x; y++) {
+    for(int y = 0; y < N; y++) {
       if(!double_equal(data[y*N+x], seq_data[y*N+x])) {
 	fprintf(stderr, "Data differs at Y = %d, X = %d: expect %.20f, but was %.20f, diff is %.20f, reldiff = %.20f\n", y, x, seq_data[y*N+x], data[y*N+x], fabs(seq_data[y*N+x] - data[y*N+x]), fabs(seq_data[y*N+x] - data[y*N+x]) / fabs(seq_data[y*N+x]));
 	exit(1);

--- a/examples/cholesky/stream_df_cholesky_peek.c
+++ b/examples/cholesky/stream_df_cholesky_peek.c
@@ -96,7 +96,7 @@ int cholesky_verify(double* matrix, double* seq_input_matrix, int N, int padding
 	dpotrf_(&upper, &N, seq_input_matrix, &Npad, &nfo);
 
 	for(int x = 0; x < N; x++) {
-		for(int y = 0; y < N-x; y++) {
+		for(int y = 0; y < N; y++) {
 			if(!double_equal(matrix[y*Npad+x], seq_input_matrix[y*Npad+x])) {
 				fprintf(stderr, "Data differs at Y = %d, X = %d: expect %.20f, but was %.20f, diff is %.20f, reldiff = %.20f\n", y, x, seq_input_matrix[y*Npad+x], matrix[y*Npad+x], fabs(seq_input_matrix[y*Npad+x] - matrix[y*Npad+x]), fabs(seq_input_matrix[y*Npad+x] - matrix[y*Npad+x]) / fabs(seq_input_matrix[y*Npad+x]));
 				return 0;

--- a/examples/cholesky/stream_df_cholesky_peek.c
+++ b/examples/cholesky/stream_df_cholesky_peek.c
@@ -399,7 +399,7 @@ static inline void create_task(struct tdesc* tdesc)
 
 void create_tasks(struct tdesc* tdesc, int ntasks, int batch)
 {
-	if(ntasks > batch) {
+	if(ntasks > batch && ntasks > 1) {
 		#pragma omp task
 		{
 			create_tasks(tdesc, ntasks / 2, batch);


### PR DESCRIPTION
Besides the fixes we have discussed, I've also enabled verification by default and over the whole matrix, so as to verify that the algorithm touched the correct matrix elements and those elements only.