### PR TITLE
DF behaviour: Allow zero-horizon windows/views

### DIFF
--- a/libworkstream_df/reuse.c
+++ b/libworkstream_df/reuse.c
@@ -141,6 +141,9 @@ void __built_in_wstream_df_prepare_data(void* v)
   wstream_df_view_p out_view = v;
   int force_reuse = 0;
 
+  if (!out_view->horizon)
+    return;
+
   /* View of a direct consumer of the task to be executed */
   wstream_df_view_p consumer_view = out_view->consumer_view;
 

--- a/libworkstream_df/wstream_df.c
+++ b/libworkstream_df/wstream_df.c
@@ -352,6 +352,8 @@ void update_numa_nodes_of_views(wstream_df_thread_p cthread, wstream_df_frame_p 
 static inline void
 tdecrease_n (void *data, size_t n, bool is_write)
 {
+  if (!n)
+    return;
 
   wstream_df_frame_p fp = (wstream_df_frame_p) data;
   wstream_df_thread_p cthread = current_thread;
@@ -717,6 +719,13 @@ wstream_df_resolve_dependences (void *v, void *s, bool is_read_view_p)
 
   wstream_df_frame_p fp = view->owner;
   int defer_further = 0;
+
+  if (!view->horizon)
+  {
+    if (!is_read_view_p)
+      tdecrease_n (fp, 1, 0);
+    return;
+  }
 
   if(is_read_view_p)
     check_add_view_to_chain(&fp->input_view_chain, view);

--- a/libworkstream_df/wstream_df.c
+++ b/libworkstream_df/wstream_df.c
@@ -1460,8 +1460,6 @@ wstream_df_resolve_n_dependences (size_t n, void *v, void *s, bool is_read_view_
       view->burst = dummy_view->burst;
       view->horizon = dummy_view->horizon;
 
-      assert(view->horizon != 0);
-
       view->owner = dummy_view->owner;
 
       if(!dummy_view->reuse_associated_view) {

--- a/libworkstream_df/wstream_df.c
+++ b/libworkstream_df/wstream_df.c
@@ -727,12 +727,12 @@ wstream_df_resolve_dependences (void *v, void *s, bool is_read_view_p)
     return;
   }
 
+  trace_state_change(current_thread, WORKER_STATE_RT_RESDEP);
+
   if(is_read_view_p)
     check_add_view_to_chain(&fp->input_view_chain, view);
   else
     check_add_view_to_chain(&fp->output_view_chain, view);
-
-  trace_state_change(current_thread, WORKER_STATE_RT_RESDEP);
 
   pthread_mutex_lock (&stream->stream_lock);
 


### PR DESCRIPTION
This aims at supporting zero-horizon windows in OpenStream programs. The  behaviour should be semantically equivalent to not referencing the respective stream at all in the task creation statement.

@a-pop commit 46ab217 removes an assertion in `wstream_df_resolve_n_dependences()`. This allows my programs to run but it will obviously cause problems. In particular, I can no longer use the `peek` clause, instead having to resort to a zero-burst `input`.

@a-pop There is an odd zero-decrease call to `tdecrease_n()` after I modified `wstream_df_resolve_dependences()` and `__built_in_wstream_df_prepare_data` so I added a guard to `tdecrease_n()`. Is this okay? There's probably a better fix once we know the reason for that call. 

@Richard549 This bypasses trace state changes on both `tdecrease_n()` and `wstream_df_resolve_dependences()` on early exists, can you please check if this is okay?